### PR TITLE
FIX: Equality check with 0 returns nan during baseline correction

### DIFF
--- a/MEEG/fuse_lfp.m
+++ b/MEEG/fuse_lfp.m
@@ -160,7 +160,7 @@ for sub = 1:Nsub
         %bc = mean(d(:)); % Don't want to mean-correct each channel/condition separately?
         bc = nan(length(Ic{m}),Nsam,Ncon);
         for c = 1:Ncon
-            bc(:,:,c) = repmat(mean(D(Ic{m},[1:find(D.time==0)],c),2),1,Nsam);
+            bc(:,:,c) = repmat(mean(D(Ic{m},[1:indsample(D, 0)],c),2),1,Nsam);
         end
         
         d = D(Ic{m},ss,ci);


### PR DESCRIPTION
Checking equality with 0 leads to silent bug due to numerical precision issues.

A fix could use either built-in `indsample` (method on `MEEG` object) or something like `abs(D.time - 0) < eps`

The current patch applies the former fix.